### PR TITLE
chore: remove issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,1 +1,0 @@
-blank_issues_enabled: false


### PR DESCRIPTION
Need to put it in the correct location.

**Description**
According to [Issue Templates Config docs](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository), it needs to go into the `ISSUE_TEMPLATE` directory and not where it was located.

**Screenshots**
N/A

**Additional context**
https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository

**Checklist**
_Have you considered all of the following?_

Please confirm by checking off each item to ensure you've considered it:

- [x] Did you create or update tests?
- [x] Did you create or update any documentation?
- [x] Did you export all new members of the lib?

---

Fixes: N/A (adhoc)
